### PR TITLE
fix(token): use correct array for refresh token parsing

### DIFF
--- a/src/Api/Token.php
+++ b/src/Api/Token.php
@@ -29,8 +29,8 @@ class Token
         }
 
         if (! empty($refresh)) {
-            $this->refresh_token = $access['token'] ?? $refresh_token;
-            $renew_in = $access['expirySeconds'] ?? $renew_in;
+            $this->refresh_token = $refresh['token'] ?? $refresh_token;
+            $renew_in = $refresh['expirySeconds'] ?? $renew_in;
         }
 
         $now = CarbonImmutable::now();


### PR DESCRIPTION
The refresh token constructor was using \ array instead of \ array when parsing refresh token data. This caused refresh tokens to be incorrectly populated from access token values.