### PR TITLE
refactor(relations): add HasMany::withPath() and simplify ChildOf

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -54,14 +54,8 @@ class Customer extends OrgUnit
      */
     public function sites(): HasMany
     {
-        $relation = $this->hasMany(Site::class);
-        $related = $relation->getBuilder()->getModel();
-
-        // Get children of this org unit
-        $related->setPath('/org-units/' . $this->customerId . '/children');
-        $related->parentModel = null;
-
-        return $relation;
+        return $this->hasMany(Site::class)
+            ->withPath('/org-units/'.$this->customerId.'/children');
     }
 
     /**
@@ -69,13 +63,7 @@ class Customer extends OrgUnit
      */
     public function devices(): HasMany
     {
-        $relation = $this->hasMany(Device::class);
-        $related = $relation->getBuilder()->getModel();
-
-        // Override the path to use org-units instead of customers
-        $related->setPath('/org-units/' . $this->customerId . '/devices');
-        $related->parentModel = null;
-
-        return $relation;
+        return $this->hasMany(Device::class)
+            ->withPath('/org-units/'.$this->customerId.'/devices');
     }
 }

--- a/src/ServiceOrganization.php
+++ b/src/ServiceOrganization.php
@@ -16,13 +16,7 @@ class ServiceOrganization extends OrgUnit
      */
     public function customers(): HasMany
     {
-        $relation = $this->hasMany(Customer::class);
-        $related = $relation->getBuilder()->getModel();
-
-        // Get children of this org unit
-        $related->setPath('/org-units/' . $this->orgUnitId . '/children');
-        $related->parentModel = null;
-
-        return $relation;
+        return $this->hasMany(Customer::class)
+            ->withPath('/org-units/'.$this->orgUnitId.'/children');
     }
 }

--- a/src/Site.php
+++ b/src/Site.php
@@ -26,13 +26,7 @@ class Site extends OrgUnit
      */
     public function devices(): HasMany
     {
-        $relation = $this->hasMany(Device::class);
-        $related = $relation->getBuilder()->getModel();
-
-        // Override the path to use org-units instead of devices
-        $related->setPath('/org-units/' . $this->orgUnitId . '/devices');
-        $related->parentModel = null;
-
-        return $relation;
+        return $this->hasMany(Device::class)
+            ->withPath('/org-units/'.$this->orgUnitId.'/devices');
     }
 }

--- a/src/Support/Relations/BelongsTo.php
+++ b/src/Support/Relations/BelongsTo.php
@@ -16,6 +16,11 @@ use Spinen\Ncentral\Support\Model;
 class BelongsTo extends Relation
 {
     /**
+     * Whether to return the child directly without querying.
+     */
+    protected bool $returnChildDirectly = false;
+
+    /**
      * Create a new belongs to relationship instance.
      *
      * @return void
@@ -57,6 +62,16 @@ class BelongsTo extends Relation
     }
 
     /**
+     * Return the child model directly without querying.
+     */
+    public function returnChildDirectly(): self
+    {
+        $this->returnChildDirectly = true;
+
+        return $this;
+    }
+
+    /**
      * Get the results of the relationship.
      *
      * @throws ApiException
@@ -67,6 +82,10 @@ class BelongsTo extends Relation
      */
     public function getResults(): ?Model
     {
+        if ($this->returnChildDirectly) {
+            return $this->getChild();
+        }
+
         if (! $this->getForeignKey()) {
             return null;
         }

--- a/src/Support/Relations/ChildOf.php
+++ b/src/Support/Relations/ChildOf.php
@@ -2,19 +2,23 @@
 
 namespace Spinen\Ncentral\Support\Relations;
 
+use Spinen\Ncentral\Exceptions\InvalidRelationshipException;
+use Spinen\Ncentral\Support\Builder;
 use Spinen\Ncentral\Support\Model;
 
 /**
  * Class ChildOf
+ *
+ * @deprecated Use BelongsTo with returnChildDirectly() instead
  */
 class ChildOf extends BelongsTo
 {
     /**
-     * Get the results of the relationship.
+     * @throws InvalidRelationshipException
      */
-    public function getResults(): Model
+    public function __construct(Builder $builder, Model $child, $foreignKey)
     {
-        // TODO: May need to deal with null relatedModel?
-        return $this->getChild();
+        parent::__construct($builder, $child, $foreignKey);
+        $this->returnChildDirectly();
     }
 }

--- a/src/Support/Relations/HasMany.php
+++ b/src/Support/Relations/HasMany.php
@@ -15,6 +15,19 @@ use Spinen\Ncentral\Support\Collection;
 class HasMany extends Relation
 {
     /**
+     * Override the path for the related model and detach from parent.
+     *
+     * Use this when the API endpoint differs from the default nested path.
+     */
+    public function withPath(string $path): self
+    {
+        $this->getRelated()->setPath($path);
+        $this->getRelated()->parentModel = null;
+
+        return $this;
+    }
+
+    /**
      * Get the results of the relationship.
      *
      * @throws ApiException


### PR DESCRIPTION
- Added HasMany::withPath() fluent method to override path and detach parent
- Refactored Customer, Site, ServiceOrganization to use withPath()
- Added BelongsTo::returnChildDirectly() method
- Simplified ChildOf to use returnChildDirectly() instead of override
- Marked ChildOf as deprecated

This eliminates the repeated 5-line path-hacking pattern and encapsulates the override logic in the relation class.