### PR TITLE
fix(error-handling): remove silent error swallowing in save/delete

### DIFF
--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -2,10 +2,8 @@
 
 namespace Spinen\Ncentral\Api;
 
-use Exception;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Str;
 use RuntimeException;
 use Spinen\Ncentral\Exceptions\ApiException;
@@ -74,32 +72,6 @@ class Client
     public function getVersion()
     {
         return new Version(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'VERSION');
-    }
-
-    /**
-     * Process exception
-     *
-     * @throws ApiException
-     * @throws GuzzleException
-     * @throws RuntimeException
-     */
-    protected function processException(GuzzleException $e): void
-    {
-        if (! is_a($e, RequestException::class)) {
-            throw $e;
-        }
-
-        /** @var RequestException $e */
-        $body = $e->getResponse()->getBody()->getContents();
-
-        $results = json_decode($body, true);
-
-        throw new ApiException(
-            body: $body,
-            code: $results['status'],
-            message: $results['message'],
-            previous: $e,
-        );
     }
 
     /**

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -305,10 +305,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Delete the model from Ncentral
      *
+     * @throws ApiException
+     * @throws GuzzleException
      * @throws InvalidCastException
      * @throws LogicException
      * @throws MissingAttributeException
      * @throws NoClientException
+     * @throws RuntimeException
      */
     public function delete(array $query = []): bool
     {
@@ -316,16 +319,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return false;
         }
 
-        try {
-            $this->getClient()
-                ->delete($this->getPath(null, $query));
+        $this->getClient()
+            ->delete($this->getPath(null, $query));
 
-            return true;
-        } catch (GuzzleException $e) {
-            // TODO: Do something with the error
-
-            return false;
-        }
+        return true;
     }
 
     /**
@@ -682,6 +679,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * Save the model in Ncentral
      *
      * @throws ApiException
+     * @throws GuzzleException
      * @throws InvalidCastException
      * @throws LogicException
      * @throws MissingAttributeException
@@ -694,27 +692,21 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return false;
         }
 
-        try {
-            if (! $this->isDirty()) {
-                return true;
-            }
-
-            $response = $this->getClient()
-                ->post($this->getPath(), $this->toArray());
-
-            $this->exists = true;
-
-            $this->wasRecentlyCreated = true;
-
-            // Reset the model with the results as we get back the full model
-            $this->setRawAttributes($this->peelWrapperPropertyIfNeeded($response), true);
-
+        if (! $this->isDirty()) {
             return true;
-        } catch (RuntimeException $e) {
-            // TODO: Should we do something with the error?
-
-            return false;
         }
+
+        $response = $this->getClient()
+            ->post($this->getPath(), $this->toArray());
+
+        $this->exists = true;
+
+        $this->wasRecentlyCreated = true;
+
+        // Reset the model with the results as we get back the full model
+        $this->setRawAttributes($this->peelWrapperPropertyIfNeeded($response), true);
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
- Model::save() now throws exceptions instead of catching and returning false
- Model::delete() now throws exceptions instead of catching and returning false
- Removed dead processException() method from Client (was never called)
- Removed unused imports (Exception, RequestException)

Callers can now properly handle API failures instead of receiving a silent false return value.